### PR TITLE
fix: cards block css refactored with flexbox

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -1,123 +1,137 @@
 .cards > ul > li {
-  border-radius: 6px;
+    border-radius: 6px;
+    width: 100%;
+    margin-bottom: 32px;
 }
 
 .cards > ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-gap: 32px;
+    list-style: none;
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: center;
+    padding: 0;
 }
 
-.cards.cta > ul > li{
-  background-color: var(--clr-neutral-200)
+.cards.cta > ul > li {
+    background-color: var(--clr-neutral-200)
 }
 
 
 .cards .cards-card-body h2,
 .cards .cards-card-body h3 {
-  text-align: center;
-  color: var(--clr-blue-700);
-  margin-bottom: 16px;
-  line-height: 36px;
+    text-align: center;
+    color: var(--clr-blue-700);
+    margin-bottom: 16px;
+    line-height: 36px;
 }
 
 .cards .cards-card-body {
-  padding: 16px;
+    padding: 16px;
 }
 
 .cards.cta .cards-card-body {
-  text-align: center;
-  padding: 32px;
+    text-align: center;
+    padding: 32px;
 }
 
-.cards.cta .cards-card-body p{
-  line-height: 24px;
+.cards.cta .cards-card-body p {
+    line-height: 24px;
 }
 
 .cards .cards-card-body p:last-child {
-  margin-bottom: 0;
+    margin-bottom: 0;
 }
 
 .cards .cards-card-body a {
-  color: var(--clr-blue-300);
+    color: var(--clr-blue-300);
 }
 
-.cards.cta .cards-card-body a.button{
-  align-items: center;
-  border: 1px solid var(--clr-blue-700);
-  border-radius: 24px;
-  box-sizing: border-box;
-  background-color: var(--clr-neutral-200);
-  color: var(--clr-blue-700);
-  display: flex;
-  justify-content: center;
-  margin-top: auto;
-  padding: 12px 24px;
-  text-decoration: none;
-  width: 100%;
-  margin-bottom: 0;
+.cards.cta .cards-card-body a.button {
+    align-items: center;
+    border: 1px solid var(--clr-blue-700);
+    border-radius: 24px;
+    box-sizing: border-box;
+    background-color: var(--clr-neutral-200);
+    color: var(--clr-blue-700);
+    display: flex;
+    justify-content: center;
+    margin-top: auto;
+    padding: 12px 24px;
+    text-decoration: none;
+    width: 100%;
+    margin-bottom: 0;
 }
 
 .cards .cards-card-image {
-  line-height: 0;
+    line-height: 0;
 }
 
 .cards > ul > li img {
-  width: 100%;
-  aspect-ratio: 6/5;
-  object-fit: cover;
-  border-radius: 6px;
+    width: 100%;
+    aspect-ratio: 6/5;
+    object-fit: cover;
+    border-radius: 6px;
 }
 
 .cards.cta > ul > li img {
-  aspect-ratio: 16/9;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
+    aspect-ratio: 16/9;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
 }
 
 @media (width >= 600px) {
-  .cards > ul {
-    grid-template-columns: 1fr 1fr 1fr;
-    grid-gap: 20px;
-  }
+    .cards > ul {
+        justify-content: space-between;
+    }
 
-  .cards.two-columns > ul {
-    grid-template-columns: 1fr 1fr;
-  }
+    .cards > ul > li {
+        width: calc(100% / 3 - 12px);
+        margin-bottom: 32px;
+    }
 
-  .cards > ul > li {
-    margin-bottom: 32px;
-  }
+    .cards.two-columns > ul > li,
+    .cards.cta > ul > li {
+        width: calc(100% / 2 - 12px);
+    }
 
-  .cards .cards-card-body h2,
-  .cards .cards-card-body h3 {
-    line-height: 44px;
-  }
+    .cards.cta > ul > li:nth-last-child(1):nth-child(odd) {
+        margin: 0 auto;
+    }
 
-  .cards .cards-card-body {
-    padding: 16px 16px 0;
-  }
+    .cards.two-columns.cta > ul > li:nth-last-child(1):nth-child(odd) {
+        margin: 0 0 32px;
+    }
 
-  .cards > ul > li img {
-    min-height: 182px;
-    min-width: 219px;
-    object-fit: cover;
-    aspect-ratio: 6/5;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
-  }
+    .cards .cards-card-body h2,
+    .cards .cards-card-body h3 {
+        line-height: 44px;
+    }
+
+    .cards .cards-card-body {
+        padding: 16px 16px 0;
+    }
+
+    .cards > ul > li img {
+        min-height: 182px;
+        min-width: 219px;
+        object-fit: cover;
+        aspect-ratio: 6/5;
+        border-bottom-left-radius: 6px;
+        border-bottom-right-radius: 6px;
+    }
 }
 
 @media (width >= 900px) {
-  .cards.cta {
-    margin: 0 100px;
-  }
+    .cards.cta > ul > li {
+        width: calc(100% / 3 - 12px);
+    }
 
-  .cards .cards-card-body {
-    padding-left: 32px;
-    padding-right: 32px;
-  }
+    .cards.two-columns > ul > li {
+        width: calc(100% / 2 - 12px);
+    }
+
+    .cards .cards-card-body {
+        padding-left: 32px;
+        padding-right: 32px;
+    }
 }

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -130,6 +130,10 @@
         width: calc(100% / 2 - 12px);
     }
 
+    .cards.cta > ul > li:nth-last-child(1):nth-child(odd) {
+        margin: 0 0 32px;
+    }
+
     .cards .cards-card-body {
         padding-left: 32px;
         padding-right: 32px;


### PR DESCRIPTION
This PR contains a css refactoring for cards block to display cards **CTA** without **two columuns** option in the right way (desktop and tablet) 
live sample: https://all.accor.com/activities-and-events/index.en.shtml 

check (Cards - CTA)

URL for testing:
- Before: https://main--accor-all--aemsites.hlx.page/tools/sidekick/blocks/cards
- After:  https://fix-cards-flexbox-refactoring--accor-all--aemsites.hlx.page/tools/sidekick/blocks/cards
